### PR TITLE
Fix missing vcs changes on qrc file paths.

### DIFF
--- a/src/plugins/projectexplorer/projectvcsstatus.h
+++ b/src/plugins/projectexplorer/projectvcsstatus.h
@@ -75,6 +75,7 @@ private:
     NodeFileList changedFileNodesForCurrentProject() const;
     NodeList updateFileNodeCache(NodeFileList & changedFileNodes);
     void removeDisappearedFileNodes(const NodeList &);
+    ProjectExplorer::FolderNode* findResourceTopLevelNode(const ProjectExplorer::FolderNode*) const;
 
 private:
     static ProjectVcsStatus * m_instance;


### PR DESCRIPTION
Pull request fixes following problem.
If the project tree contains artificial resource nodes, there is no highlighting for VCS changes in the project tree like
 
![image](https://user-images.githubusercontent.com/2613713/167095012-eff7f36d-af0c-4adb-9f96-3c58c5747d73.png)
